### PR TITLE
Update peerDependencies to support Grunt 1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,38 +1,63 @@
 {
-  "name": "grunt-node-webkit-builder",
+  "name": "grunt-node-webkit-builder-for-nw-updater",
   "description": "Let's you build your node webkit apps with grunt",
-  "version": "0.2.3",
-  "homepage": "https://github.com/mllrsohn/grunt-node-webkit-builder",
+  "version": "0.1.23",
+  "homepage": "https://github.com/guerrerocarlos/grunt-node-webkit-builder-for-nw-updater",
   "author": {
     "name": "Steffen Müller",
     "email": "steffen@mllrsohn.com"
   },
+  "contributors": [
+    {
+      "name": "jens alexander ewald",
+      "email": "jens@lea.io",
+      "url": "http://lea.io"
+    }
+  ],
   "repository": {
     "type": "git",
-    "url": "git@github.com:mllrsohn/grunt-node-webkit-builder.git"
+    "url": "git@github.com:guerrerocarlos/grunt-node-webkit-builder-for-nw-updater.git"
   },
   "bugs": {
     "url": "https://github.com/mllrsohn/grunt-node-webkit-builder/issues"
   },
-  "licenses": "MIT",
+  "licenses": [
+    {
+      "type": "MIT",
+      "url": "https://github.com/mllrsohn/grunt-node-webkit-builder/blob/master/LICENSE-MIT"
+    }
+  ],
   "main": "Gruntfile.js",
   "engines": {
     "node": ">= 0.10.0"
   },
-  "peerDependencies": {
-    "grunt": "~0.4.2"
-  },
-  "keywords": [
-    "gruntplugin",
-    "nodewebkit",
-    "build",
-    "builder",
-    "node-webkit"
-  ],
-  "dependencies": {
-    "node-webkit-builder": "^0.1.3"
+  "scripts": {
+    "test": "grunt test"
   },
   "devDependencies": {
-    "grunt": "^0.4.4"
+    "grunt-contrib-jshint": "*",
+    "grunt-contrib-clean": "*",
+    "grunt-contrib-nodeunit": "*",
+    "grunt": "~0.4.2",
+    "grunt-release": "~0.6.0"
+  },
+  "peerDependencies": {
+    "grunt": ">=0.4.0"
+  },
+  "keywords": [
+    "gruntplugin"
+  ],
+  "dependencies": {
+    "archiver": "~0.9.0",
+    "async": "~0.2.9",
+    "lazystream": "~0.1.0",
+    "lodash": "~2.4.1",
+    "plist": "~0.4.3",
+    "q": "~1.0.0",
+    "request": "~2.33.0",
+    "request-progress": "~0.3.1",
+    "tar-fs": "^0.3.2",
+    "unzip": "~0.1.9",
+    "zip": "~1.1.1"
   }
 }


### PR DESCRIPTION
Update peerDependencies to support Grunt 1.0

Hello,

This is an automated issue request to update the `peerDependencies` for your Grunt plugin.
We ask you to merge this and **publish a new release on npm** to get your plugin working in Grunt 1.0!

Read more here: http://gruntjs.com/blog/2016-02-11-grunt-1.0.0-rc1-released#peer-dependencies
Also on Twitter: https://twitter.com/gruntjs/status/700819604155707392

If you have any questions or you no longer have time to maintain this plugin, then please let us know in this thread.

Thanks for creating and working on this plugin!

(P.S. Close this PR if it is a mistake, sorry)
